### PR TITLE
fix: avoid duplicate id error

### DIFF
--- a/direct-open/background.js
+++ b/direct-open/background.js
@@ -1,7 +1,7 @@
 import { genLambdaUrlFromSelection } from './scripts/url.mjs';
 import { saveFunctionHistoryMenuSelect } from './scripts/history.mjs';
 
-chrome.runtime.onInstalled.addListener(() => {
+function createContextMenuItems() {
   const parent = chrome.contextMenus.create({
     id: 'share',
     title: 'Open Lambda Page',
@@ -28,6 +28,14 @@ chrome.runtime.onInstalled.addListener(() => {
     title: 'Options',
     contexts: ['all'],
   });
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  createContextMenuItems();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  createContextMenuItems();
 });
 
 async function menuAction(info, tab, action) {


### PR DESCRIPTION
- https://github.com/shimo164/direct-open-lambda-page/issues/21

> The error you're encountering suggests that you're trying to create a context menu item with a duplicate id 'share'. To fix this, make sure you're only creating the context menu items once. You can do this by wrapping the menu creation code in a function and calling it only if needed.