### PR TITLE
feat,refactor: Inactive if region is not set. Refactor js files.

### DIFF
--- a/direct-open/scripts/history.mjs
+++ b/direct-open/scripts/history.mjs
@@ -1,25 +1,16 @@
 import { swap } from './util.mjs';
 
-function saveFunctionHistoryMenuSelect(fnName) {
-  // On menu selection, save without load history
-  chrome.storage.local.get('fnNames', (items) => {
-    const savedFnNames = items.fnNames;
+async function saveFunctionHistoryMenuSelect(fnName) {
+  const { fnNames: savedFnNames = [] } = await chrome.storage.local.get(
+    'fnNames',
+  );
 
-    // fnNames is empty or undefined
-    if (savedFnNames === '' || savedFnNames === undefined) {
-      chrome.storage.local.set({ fnNames: [fnName] });
-      return;
-    }
+  const index = savedFnNames.findIndex((el) => el === fnName);
 
-    // If fnName is already in the array, swap to index 0
-    // if not, add fnName at index = 0
-    const index = savedFnNames.findIndex((el) => el === fnName);
-    if (index !== -1) {
-      chrome.storage.local.set({ fnNames: swap(savedFnNames, 0, index) });
-    } else {
-      chrome.storage.local.set({ fnNames: [fnName].concat(savedFnNames) });
-    }
-  });
+  const newFnNames =
+    index !== -1 ? swap(savedFnNames, 0, index) : [fnName, ...savedFnNames];
+
+  chrome.storage.local.set({ fnNames: newFnNames });
 }
 
 export { saveFunctionHistoryMenuSelect };

--- a/direct-open/scripts/url.mjs
+++ b/direct-open/scripts/url.mjs
@@ -1,21 +1,19 @@
-function generateTargetUrl(action, region, fnName) {
-  let targetUrl = '';
+const targetUrlActions = {
+  lambda_console: (region, fnName) =>
+    `https://${region}.console.aws.amazon.com/lambda/home?region=${region}#/functions/${fnName}?tab=code`,
+  lambda_logs: (region, fnName) =>
+    `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logStream:group=%252Faws%252Flambda%252F${fnName}`,
+};
 
-  if (action === 'lambda_console') {
-    targetUrl = `https://${region}.console.aws.amazon.com/lambda/home?region=${region}#/functions/${fnName}?tab=code`;
-  } else if (action === 'lambda_logs') {
-    targetUrl = `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logStream:group=%252Faws%252Flambda%252F${fnName}`;
-  }
-  return targetUrl;
+function generateTargetUrl(action, region, fnName) {
+  const urlGenerator = targetUrlActions[action];
+  return urlGenerator ? urlGenerator(region, fnName) : '';
 }
 
 async function genLambdaUrlFromSelection(info, action) {
-  const region = await chrome.storage.local
-    .get(['region'])
-    .then((result) => result.region);
+  const { region } = await chrome.storage.local.get(['region']);
 
   const fnName = info.selectionText;
-
   const targetUrl = generateTargetUrl(action, region, fnName);
 
   return { targetUrl, fnName };

--- a/direct-open/scripts/util.mjs
+++ b/direct-open/scripts/util.mjs
@@ -4,15 +4,14 @@ function swap(array, i1, i2) {
 }
 
 function removeOptions(selectElement) {
-  let i;
-  const L = selectElement.options.length - 1;
-  for (i = L; i >= 0; i -= 1) {
+  const { length } = selectElement.options;
+  for (let i = length - 1; i >= 0; i -= 1) {
     selectElement.remove(i);
   }
 }
 
 function spliceArray(array, index) {
-  if (array.length !== 0 && index !== -1) {
+  if (index !== -1) {
     array.splice(index, 1);
   }
 }


### PR DESCRIPTION
- https://github.com/shimo164/direct-open-lambda-page/issues/18

## Inactive if region is not set

This commit introduces a change in the handling of context menus within the application. Previously, the 'Lambda Console' and 'Lambda Logs' context menu items were always active, regardless of whether a region was set. 

The new changes ensure that these context menu items are inactive (not created) until a region is defined. This helps prevent unexpected behavior and prompts users to set the region before they can interact with these menu options. 

This behavior is accomplished by adjusting the `createContextMenuItems` function to check if a region has been set before creating the context menu items. Furthermore, event listeners for `chrome.runtime.onInstalled`, `chrome.runtime.onStartup`, and `chrome.storage.onChanged` have been refactored to handle this new workflow.


## refactor

1. Adopted async/await syntax to simplify asynchronous operations.
2. Optimized function logic in 'saveFunctionHistoryMenuSelect' by implementing array destructuring.
3. Simplified the URL generation process in 'genLambdaUrlFromSelection' and 'generateTargetUrl' by using an object for action-URL mapping.
4. Refined 'swap', 'removeOptions', and 'spliceArray' functions in util.mjs for better performance and simplicity.
5. Removed unnecessary checks in the 'spliceArray' function.