### PR TITLE
fix: add promise-based-lock

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Issue ticket number and link
+
+
+## Describe your changes
+


### PR DESCRIPTION
## Issue ticket number and link
- #24 


## Describe your changes
Implemented a Promise-based lock mechanism in createContextMenuItems to ensure previous context menu cleanup and creation operation is completed before a new one begins.
This lock mechanism prevents potential errors related to creating context menus with duplicate IDs concurrently.
