### PR TITLE
Fix duplicate context menum id errors

### DIFF
--- a/direct-open/background.js
+++ b/direct-open/background.js
@@ -13,46 +13,41 @@ async function getXrayOption() {
 
 let menuCreationPromise = null;
 
-function createContextMenuItems(regionSet = false, xrayOption = false) {
-  // Store promise of menu creation in variable
-  menuCreationPromise = new Promise((resolve) => {
-    chrome.contextMenus.removeAll(() => {
-      // Code for creating new context menu items should be inside the callback
-      const parent = chrome.contextMenus.create({
-        id: 'share',
-        title: 'Open Lambda Page',
-        contexts: ['all'],
-      });
+let isCreatingMenu = false;
 
-      if (regionSet) {
-        ['Lambda Console', 'Lambda Logs'].forEach((title, i) => {
-          chrome.contextMenus.create({
-            parentId: parent,
-            id: `lambda-${i === 0 ? 'console' : 'logs'}`,
-            title: title,
-            contexts: ['selection'],
-          });
-        });
-        if (xrayOption) {
-          chrome.contextMenus.create({
-            parentId: parent,
-            id: 'lambda-trace',
-            title: 'X-Ray Trace',
-            contexts: ['selection'],
-          });
-        }
-      }
+async function createContextMenuItems(regionSet = false) {
+  if (isCreatingMenu) {
+    return;
+  }
 
-      chrome.contextMenus.create({
-        parentId: parent,
-        id: 'options',
-        title: 'Options',
-        contexts: ['all'],
-      });
+  isCreatingMenu = true;
 
-      // Resolve the promise when we're done
-      resolve();
+  chrome.contextMenus.removeAll(() => {
+    const parent = chrome.contextMenus.create({
+      id: 'share',
+      title: 'Open Lambda Page',
+      contexts: ['all'],
     });
+
+    if (regionSet) {
+      ['Lambda Console', 'Lambda Logs', 'X-Ray Trace'].forEach((title, i) => {
+        chrome.contextMenus.create({
+          parentId: parent,
+          id: `lambda-${i === 0 ? 'console' : i === 1 ? 'logs' : 'trace'}`,
+          title: title,
+          contexts: ['selection'],
+        });
+      });
+    }
+
+    chrome.contextMenus.create({
+      parentId: parent,
+      id: 'options',
+      title: 'Options',
+      contexts: ['all'],
+    });
+
+    isCreatingMenu = false;
   });
 }
 


### PR DESCRIPTION
## Issue ticket number and link
- fix #24 

## Describe your changes

Implemented a locking mechanism in the createContextMenuItems() function in background.js to prevent it from executing multiple times concurrently, which was causing the creation of duplicate context menu IDs.

This fix prevents chrome.contextMenus.create() from executing before chrome.contextMenus.removeAll() has finished, ensuring that all context menu items are properly removed before new ones are created.
