### PR TITLE
fix: menu flag to check already created

### DIFF
--- a/direct-open/background.js
+++ b/direct-open/background.js
@@ -4,46 +4,51 @@ import { getRegion, getXrayOption } from './scripts/util.mjs';
 
 let menuCreationPromise = null;
 
+let menuCreated = false; // flag variable
+
 function createContextMenuItems(regionSet = false, xrayOption = false) {
-  // Store promise of menu creation in variable
-  menuCreationPromise = new Promise((resolve) => {
-    chrome.contextMenus.removeAll(() => {
-      // Code for creating new context menu items should be inside the callback
-      const parent = chrome.contextMenus.create({
-        id: 'share',
-        title: 'Open Lambda Page',
-        contexts: ['all'],
-      });
+  // Check if menu is already created
+  if (menuCreated) {
+    return;
+  }
 
-      if (regionSet) {
-        ['Lambda Console', 'Lambda Logs'].forEach((title, i) => {
-          chrome.contextMenus.create({
-            parentId: parent,
-            id: `lambda-${i === 0 ? 'console' : 'logs'}`,
-            title: title,
-            contexts: ['selection'],
-          });
-        });
-        if (xrayOption) {
-          chrome.contextMenus.create({
-            parentId: parent,
-            id: 'lambda-trace',
-            title: 'X-Ray Trace',
-            contexts: ['selection'],
-          });
-        }
-      }
-
-      chrome.contextMenus.create({
-        parentId: parent,
-        id: 'options',
-        title: 'Options',
-        contexts: ['all'],
-      });
-
-      // Resolve the promise when we're done
-      resolve();
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: 'share',
+      title: 'Open Lambda Page',
+      contexts: ['all'],
     });
+
+    if (regionSet) {
+      ['Lambda Console', 'Lambda Logs'].forEach((title, i) => {
+        const id = `lambda-${i === 0 ? 'console' : 'logs'}`;
+        chrome.contextMenus.create({
+          parentId: 'share',
+          id,
+          title: title,
+          contexts: ['selection'],
+        });
+      });
+
+      if (xrayOption) {
+        chrome.contextMenus.create({
+          parentId: 'share',
+          id: 'lambda-trace',
+          title: 'X-Ray Trace',
+          contexts: ['selection'],
+        });
+      }
+    }
+
+    chrome.contextMenus.create({
+      parentId: 'share',
+      id: 'options',
+      title: 'Options',
+      contexts: ['all'],
+    });
+
+    // Set flag to true
+    menuCreated = true;
   });
 }
 


### PR DESCRIPTION
## Issue ticket number and link
- #24 

## Describe your changes
This PR introduces a solution to prevent the duplication of context menu items by implementing a flag to track whether the menu items have already been created. It addresses an issue where the context menu items were being created multiple times, leading to redundant entries.

Changes include:

Introduced a menuCreated flag that is set to true once the context menu items are created for the first time.
Modified createContextMenuItems function to return early if menuCreated is true, preventing the creation of duplicate menu items.
