### PR TITLE
fix: not to save xray ids

### DIFF
--- a/direct-open/background.js
+++ b/direct-open/background.js
@@ -75,7 +75,9 @@ chrome.storage.onChanged.addListener(async (changes, namespace) => {
 
 async function menuAction(info, tab, action) {
   const { targetUrl, fnName } = await genLambdaUrlFromSelection(info, action);
-  saveFunctionHistoryMenuSelect(fnName);
+  if (action !== 'xray_trace') {
+    saveFunctionHistoryMenuSelect(fnName);
+  }
   chrome.tabs.create({ url: targetUrl });
 }
 


### PR DESCRIPTION
## Issue ticket number and link

- #32 

## Describe your changes

With the action 'xray_trace', function name(trace id) should not be saved.
