### PR TITLE
fix: create menu context when save settings on install

### DIFF
--- a/direct-open/background.js
+++ b/direct-open/background.js
@@ -29,15 +29,14 @@ function createContextMenuItems(regionSet = false, xrayOption = false) {
           contexts: ['selection'],
         });
       });
-
-      if (xrayOption) {
-        chrome.contextMenus.create({
-          parentId: 'share',
-          id: 'lambda-trace',
-          title: 'X-Ray Trace',
-          contexts: ['selection'],
-        });
-      }
+    }
+    if (xrayOption) {
+      chrome.contextMenus.create({
+        parentId: 'share',
+        id: 'lambda-trace',
+        title: 'X-Ray Trace',
+        contexts: ['selection'],
+      });
     }
 
     chrome.contextMenus.create({
@@ -95,3 +94,5 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   const action = menuItemActions[info.menuItemId];
   if (action) await action(info, tab);
 });
+
+export { createContextMenuItems };

--- a/direct-open/options.js
+++ b/direct-open/options.js
@@ -1,5 +1,6 @@
 import { generateTargetUrl } from './scripts/urlProcessor.mjs';
 import { getRegion } from './scripts/util.mjs';
+import { createContextMenuItems } from './background.js';
 import {
   saveFunctionHistory,
   loadFunctionHistory,
@@ -26,11 +27,13 @@ async function loadRegion() {
 }
 
 function saveOptions() {
-  const value = getElem('inputRegion').value;
-  chrome.storage.local.set({ region: value });
+  const region = getElem('inputRegion').value;
+  chrome.storage.local.set({ region: region });
 
   const xrayOption = getElem('xrayOption').checked;
   chrome.storage.local.set({ xrayOption });
+
+  createContextMenuItems(!!region, !!xrayOption);
 
   getElem('saveMessage').innerHTML = `Saved at ${new Date().toLocaleString()}`;
 }


### PR DESCRIPTION
## Issue ticket number and link
- #44 

## Describe your changes

called `createContextMenuItems` at the end of the save function in options.js.
