### PR TITLE
fix: menuCreted flag should be re-defined

### DIFF
--- a/direct-open/background.js
+++ b/direct-open/background.js
@@ -7,12 +7,10 @@ let menuCreationPromise = null;
 let menuCreated = false;
 
 function createContextMenuItems(regionSet = false) {
-  // Check if menu is already created
-  if (menuCreated) {
-    return;
-  }
-
+  // Remove all existing context menus and reset the flag
   chrome.contextMenus.removeAll(() => {
+    menuCreated = false;
+
     chrome.contextMenus.create({
       id: 'share',
       title: 'Open Lambda Page',
@@ -42,6 +40,7 @@ function createContextMenuItems(regionSet = false) {
       title: 'Options',
       contexts: ['all'],
     });
+
     menuCreated = true;
   });
 }


### PR DESCRIPTION
## Issue ticket number and link

- #50 

## Describe your changes
Refactored the context menu initialization in background.js to ensure the creation of menu items only happens once.
Cleaned up the event listeners to prevent possible double triggers.
